### PR TITLE
chore: remove unnecessary query parse if not cache

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -53,7 +53,7 @@ class GraphQLFastify {
       const isIntroQuery = isIntrospectionQuery(operationName);
       const context = this.config.context?.(request) || {};
 
-      const parsedQuery = parse(query);
+      const parsedQuery = this.cache ? parse(query) : undefined;
       const { ttl, isPrivate } =
         getCacheTtl(parsedQuery, this.config.cache?.policy, operationName) || {};
 
@@ -74,7 +74,7 @@ class GraphQLFastify {
       let compiledQuery = this.queriesCache.get(queryCacheKey);
 
       if (!compiledQuery) {
-        const compilationResult = compileQuery(schema, parsedQuery, operationName);
+        const compilationResult = compileQuery(schema, parsedQuery || parse(query), operationName);
 
         if (isCompiledQuery(compilationResult)) {
           compiledQuery = compilationResult;

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -18,11 +18,11 @@ export const isIntrospectionQuery = (operationName?: string): boolean => {
  * @returns It returns the ttl of the cache. If it's 0 then the query it's not cacheable
  */
 export const getCacheTtl = (
-  query: DocumentNode,
+  query?: DocumentNode,
   cachePolicy?: CachePolicy,
   operationName?: string
 ): CacheInformation | null => {
-  if (!cachePolicy) return null;
+  if (!query || !cachePolicy) return null;
   const {
     selectionSet: { selections },
   } = getOperation(query.definitions, operationName);


### PR DESCRIPTION
This PR removes the unnecessary query parse if the cache config is not specified.